### PR TITLE
Add MacPorts as a new installation method

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,6 +294,12 @@ Alternatively, use the custom tap (which is updated immediately after a release)
 brew install jdxcode/tap/rtx
 ```
 
+#### MacPorts
+
+```
+sudo port install rtx
+```
+
 #### Cargo
 
 Build from source with Cargo:


### PR DESCRIPTION
I have created a new port for rtx in https://github.com/macports/macports-ports/pull/19817. Now users can install RTX through MacPorts. This PR add this information to the README.